### PR TITLE
fixs #39 currentSession.user not updated

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -255,6 +255,13 @@ class GoTrueClient {
     if (response.error != null) return response;
 
     currentUser = response.user;
+    currentSession = Session(
+        accessToken: currentSession.accessToken,
+        expiresIn: currentSession.expiresAt,
+        refreshToken: currentSession.refreshToken,
+        tokenType: currentSession.tokenType,
+        providerToken: currentSession.providerToken,
+        user: response.user);
     _notifyAllSubscribers(AuthChangeEvent.userUpdated);
 
     return response;


### PR DESCRIPTION
This PR fixes issue #39

In the method `GoTrueClient.update()`, only `currentUser` is updated. The `curerntSession.user` variable is not updated, causing these two variables to fall out of sync.