### PR TITLE
add `toString` method to `GotrueError`class

### DIFF
--- a/lib/src/gotrue_error.dart
+++ b/lib/src/gotrue_error.dart
@@ -2,4 +2,9 @@ class GotrueError {
   String message;
 
   GotrueError(this.message);
+
+  @override
+  String toString() {
+    return 'GotrueError(message: $message)';
+  }
 }


### PR DESCRIPTION
When printing `response.error`, it'll print for example:
```
GotrueError(message: Database error querying schema)
```

Instead of:
```
Instance of 'GotrueError'
```