### PR TITLE
fix: missing event on session recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.4]
+
+- fix: trigger signedIn event on recoverSession
+
 ## [0.1.3]
 
 - feat: add `tokenRefreshed` auth event

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -330,6 +330,7 @@ class GoTrueClient {
         }
       } else {
         _saveSession(session);
+        _notifyAllSubscribers(AuthChangeEvent.signedIn);
         return GotrueSessionResponse(data: session);
       }
     } catch (e) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.3';
+const version = '0.1.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 0.1.3
+version: 0.1.4
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/gotrue-dart"
 


### PR DESCRIPTION
> @osaxma I found out that the error only occurs when I recover auth session. In other words, subscribing after login directly doesn't have an issue, but subscribing after a session recovery has the issue.

> The issue is that onAuthStateChange does not trigger an event after a session recovery, which is used to update the accessToken for the realtime client in here:
https://github.com/supabase-community/supabase-dart/blob/2d5be1c6968da5944f8b3b039e351b38a953d815/lib/src/supabase.dart#L169-L180
If gotrue-dart emits a signedIn or tokenRefreshed event after session recovery, this issue would be fixed.

https://github.com/supabase-community/realtime-dart/issues/35#issuecomment-1024998157