### PR TITLE
add jwt to headers when refreshing token

### DIFF
--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -351,7 +351,10 @@ class GoTrueApi {
   }
 
   /// Generates a new JWT.
-  Future<GotrueSessionResponse> refreshAccessToken(String refreshToken, [String? jwt]) async {
+  Future<GotrueSessionResponse> refreshAccessToken(
+    String refreshToken, [
+    String? jwt,
+  ]) async {
     try {
       final body = {'refresh_token': refreshToken};
       if (jwt != null) {

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -351,9 +351,12 @@ class GoTrueApi {
   }
 
   /// Generates a new JWT.
-  Future<GotrueSessionResponse> refreshAccessToken(String refreshToken) async {
+  Future<GotrueSessionResponse> refreshAccessToken(String refreshToken, [String? jwt]) async {
     try {
       final body = {'refresh_token': refreshToken};
+      if (jwt != null) {
+        headers['Authorization'] = 'Bearer $jwt';
+      }
       final options = FetchOptions(headers);
       final response = await fetch
           .post('$url/token?grant_type=refresh_token', body, options: options);

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -322,8 +322,10 @@ class GoTrueClient {
       final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
       if (expiresAt < timeNow) {
         if (autoRefreshToken && session.refreshToken != null) {
-          final response =
-              await _callRefreshToken(refreshToken: session.refreshToken);
+          final response = await _callRefreshToken(
+            refreshToken: session.refreshToken,
+            accessToken: session.accessToken,
+          );
           return response;
         } else {
           return GotrueSessionResponse(error: GotrueError('Session expired.'));
@@ -418,14 +420,16 @@ class GoTrueClient {
 
   Future<GotrueSessionResponse> _callRefreshToken({
     String? refreshToken,
+    String? accessToken,
   }) async {
     final token = refreshToken ?? currentSession?.refreshToken;
+    final jwt = accessToken ?? currentSession?.accessToken;
     if (token == null) {
       final error = GotrueError('No current session.');
       return GotrueSessionResponse(error: error);
     }
 
-    final response = await api.refreshAccessToken(token);
+    final response = await api.refreshAccessToken(token, jwt);
     if (response.error != null) return response;
     if (response.data == null) {
       final error = GotrueError('Invalid session data.');


### PR DESCRIPTION
Closes https://github.com/supabase-community/gotrue-dart/issues/52

Summary:
add the `JWT` as an `Authorization` header when refreshing tokens. 

