### PR TITLE
refreshToken: signout on failure

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -430,9 +430,13 @@ class GoTrueClient {
     }
 
     final response = await api.refreshAccessToken(token, jwt);
-    if (response.error != null) return response;
+    if (response.error != null) {
+      await signOut();
+      return response;
+    }
     if (response.data == null) {
       final error = GotrueError('Invalid session data.');
+      await signOut();
       return GotrueSessionResponse(error: error);
     }
 


### PR DESCRIPTION
This is not optimal, we probably want to detect network failure and retry refreshing the auth token.

At least the client get notified that something is wrong. Paired with a one week refresh token that's a good enough workaround for the moment :)

Waiting for instruction to implement the proper solution to supabase-community/supabase-flutter#82