### PR TITLE
feat: set user metadata on sign up

### DIFF
--- a/lib/src/auth_options.dart
+++ b/lib/src/auth_options.dart
@@ -1,12 +1,17 @@
+import 'package:gotrue/gotrue.dart';
+
 class AuthOptions {
+  /// A URL or mobile address to send the user to after they are confirmed.
   final String? redirectTo;
+
+  /// A space-separated list of scopes granted to the OAuth application.
   final String? scopes;
 
+  /// Set [User.userMetadata] on sign up
+  final Map<String, dynamic>? userMetadata;
   AuthOptions({
-    /// A URL or mobile address to send the user to after they are confirmed.
     this.redirectTo,
-
-    /// A space-separated list of scopes granted to the OAuth application.
     this.scopes,
+    this.userMetadata,
   });
 }

--- a/lib/src/auth_options.dart
+++ b/lib/src/auth_options.dart
@@ -1,5 +1,3 @@
-import 'package:gotrue/gotrue.dart';
-
 class AuthOptions {
   /// A URL or mobile address to send the user to after they are confirmed.
   final String? redirectTo;
@@ -7,11 +5,8 @@ class AuthOptions {
   /// A space-separated list of scopes granted to the OAuth application.
   final String? scopes;
 
-  /// Set [User.userMetadata] on sign up
-  final Map<String, dynamic>? userMetadata;
   AuthOptions({
     this.redirectTo,
     this.scopes,
-    this.userMetadata,
   });
 }

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -11,16 +11,19 @@ class GoTrueApi {
       : headers = headers ?? {};
 
   /// Creates a new user using their email address.
+  ///
+  /// [userMetadata] sets [User.userMetadata] without an extra call to [updateUser]
   Future<GotrueSessionResponse> signUpWithEmail(
     String email,
     String password, {
     AuthOptions? options,
+    Map<String, dynamic>? userMetadata,
   }) async {
     try {
       final body = {
         'email': email,
         'password': password,
-        'data': options?.userMetadata
+        'data': userMetadata,
       };
       final fetchOptions = FetchOptions(headers);
       final urlParams = [];
@@ -84,16 +87,23 @@ class GoTrueApi {
 
   /// Signs up a new user using their phone number and a password.
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   ///
-  /// `password` is the password of the user
+  /// [password] is the password of the user
+  ///
+  /// [userMetadata] sets [User.userMetadata] without an extra call to [updateUser]
   Future<GotrueSessionResponse> signUpWithPhone(
     String phone,
-    String password,
-  ) async {
+    String password, {
+    Map<String, dynamic>? userMetadata,
+  }) async {
     try {
       final fetchOptions = FetchOptions(headers);
-      final body = {'phone': phone, 'password': password};
+      final body = {
+        'phone': phone,
+        'password': password,
+        'data': userMetadata,
+      };
       final response =
           await fetch.post('$url/signup', body, options: fetchOptions);
 
@@ -115,9 +125,9 @@ class GoTrueApi {
 
   /// Logs in an existing user using their phone number and password.
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   ///
-  /// `password` is the password of the user
+  /// [password] is the password of the user
   Future<GotrueSessionResponse> signInWithPhone(
     String phone, [
     String? password,
@@ -176,7 +186,7 @@ class GoTrueApi {
 
   /// Sends a mobile OTP via SMS. Will register the account if it doesn't already exist
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   Future<GotrueJsonResponse> sendMobileOTP(String phone) async {
     try {
       final body = {'phone': phone};
@@ -197,9 +207,9 @@ class GoTrueApi {
 
   /// Send User supplied Mobile OTP to be verified
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   ///
-  /// `token` is the token that user was sent to their mobile phone
+  /// [token] is the token that user was sent to their mobile phone
   Future<GotrueSessionResponse> verifyMobileOTP(
     String phone,
     String token, {
@@ -388,8 +398,12 @@ class GoTrueApi {
   }
 
   // TODO: not implemented yet
-  void setAuthCookie() {}
+  Never setAuthCookie() {
+    throw UnimplementedError();
+  }
 
   // TODO: not implemented yet
-  void getUserByCookie() {}
+  Never getUserByCookie() {
+    throw UnimplementedError();
+  }
 }

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -17,7 +17,11 @@ class GoTrueApi {
     AuthOptions? options,
   }) async {
     try {
-      final body = {'email': email, 'password': password};
+      final body = {
+        'email': email,
+        'password': password,
+        'data': options?.userMetadata
+      };
       final fetchOptions = FetchOptions(headers);
       final urlParams = [];
       if (options?.redirectTo != null) {

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -49,15 +49,22 @@ class GoTrueClient {
   }
 
   /// Creates a new user.
+  ///
+  /// [userMetadata] sets [User.userMetadata] without an extra call to [update]
   Future<GotrueSessionResponse> signUp(
     String email,
     String password, {
     AuthOptions? options,
+    Map<String, dynamic>? userMetadata,
   }) async {
     _removeSession();
 
-    final response =
-        await api.signUpWithEmail(email, password, options: options);
+    final response = await api.signUpWithEmail(
+      email,
+      password,
+      options: options,
+      userMetadata: userMetadata,
+    );
     if (response.error != null) return response;
 
     // ignore: deprecated_member_use_from_same_package
@@ -72,17 +79,21 @@ class GoTrueClient {
 
   /// Signs up a new user using their phone number and a password.
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   ///
-  /// `password` is the password of the user
+  /// [password] is the password of the user
+  ///
+  /// [userMetadata] sets [User.userMetadata] without an extra call to [update]
   Future<GotrueSessionResponse> signUpWithPhone(
     String phone,
     String password, {
     AuthOptions? options,
+    Map<String, dynamic>? userMetadata,
   }) async {
     _removeSession();
 
-    final response = await api.signUpWithPhone(phone, password);
+    final response =
+        await api.signUpWithPhone(phone, password, userMetadata: userMetadata);
     if (response.error != null) return response;
 
     if (response.data?.user?.phoneConfirmedAt != null) {
@@ -129,9 +140,9 @@ class GoTrueClient {
 
   /// Log in a user given a User supplied OTP received via mobile.
   ///
-  /// `phone` is the user's phone number WITH international prefix
+  /// [phone] is the user's phone number WITH international prefix
   ///
-  /// `token` is the token that user was sent to their mobile phone
+  /// [token] is the token that user was sent to their mobile phone
   Future<GotrueSessionResponse> verifyOTP(
     String phone,
     String token, {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -46,6 +46,7 @@ void main() {
         email,
         password,
         options: AuthOptions(redirectTo: 'https://localhost:9999/welcome'),
+        userMetadata: {"Hello": "World"},
       );
       final data = response.data;
       final error = response.error;
@@ -53,6 +54,7 @@ void main() {
       expect(data?.accessToken, isA<String>());
       expect(data?.refreshToken, isA<String>());
       expect(data?.user?.id, isA<String>());
+      expect(data?.user?.userMetadata, {"Hello": "World"});
     });
 
     test('signIn()', () async {


### PR DESCRIPTION
So far it wasn't possible to set `userMetadata` on sign up. A second request was necessary. If only one request comes through, it could cause problems. 
I saw in `gotrue-js` [that it's possible](https://github.com/supabase/gotrue-js/blob/12d02c35209bbd9f8f51af8d0aeee5e86fcc2a6e/src/GoTrueApi.ts#L91) and tested it with the supabse cli local.

In addition, I put the comments from `AuthOptions` to the correct position, because it wasn't shown in VS Code on the parameters.