### PR TITLE
chore: publish version 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [next]
 
+## [0.1.6]
+
 - fix: fetch the user, if missing, on `/verify` ([#29](https://github.com/supabase-community/gotrue-dart/issues/29))
 - feat: add JWT headers when refreshing token  ([#53](https://github.com/supabase-community/gotrue-dart/pull/53))
 - feat: add `signInWithOpenIDConnect`  ([#61](https://github.com/supabase-community/gotrue-dart/pull/61))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## [next]
-
 ## [0.1.6]
 
 - fix: fetch the user, if missing, on `/verify` ([#29](https://github.com/supabase-community/gotrue-dart/issues/29))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [next]
 
 - fix: fetch the user, if missing, on `/verify` ([#29](https://github.com/supabase-community/gotrue-dart/issues/29))
+- feat: add JWT headers when refreshing token  ([#53](https://github.com/supabase-community/gotrue-dart/pull/53))
+- feat: add `signInWithOpenIDConnect`  ([#61](https://github.com/supabase-community/gotrue-dart/pull/61))
 
 ## [0.1.5]
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.5';
+const version = '0.1.6';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 0.1.5
+version: 0.1.6
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/gotrue-dart"
 


### PR DESCRIPTION
Publish new version of gotrue-dart to be used inside of supabase-dart