### PR TITLE
feat: add false_secrets to pubspec to be able to bypass leak detection

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
 version: 0.1.6
-homepage: "https://supabase.io"
-repository: "https://github.com/supabase/gotrue-dart"
+homepage: 'https://supabase.io'
+repository: 'https://github.com/supabase/gotrue-dart'
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   http: ^0.13.0
@@ -15,3 +15,6 @@ dev_dependencies:
   dotenv: ^3.0.0
   lint: ^1.5.1
   test: ^1.16.4
+
+false_secrets:
+  - /infra/docker-compose.yml


### PR DESCRIPTION
It seems like the pub.dev started detecting potential leaks of secrets. The leak detection detected the following line from `infra/docker-compose.yml` as leak of secret, and in order to publish a package, I had to add false_secrets to `pubspek.yml` file. 

```yml
GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: 53566906701-bmhc1ndue7hild39575gkpimhs06b7ds.apps.googleusercontent.com
```

https://dart.dev/tools/pub/pubspec#false_secrets