### PR TITLE
feat: custom http client and statuscode in response

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -4,15 +4,24 @@ import 'package:gotrue/src/fetch_options.dart';
 import 'package:gotrue/src/gotrue_error.dart';
 import 'package:gotrue/src/gotrue_response.dart';
 import 'package:http/http.dart' as http;
-
-final Fetch fetch = Fetch();
+import 'package:http/http.dart';
 
 class Fetch {
+  final Client? httpClient;
+
+  Fetch([this.httpClient]);
+
   bool isSuccessStatusCode(int code) {
     return code >= 200 && code <= 299;
   }
 
-  GotrueError handleError(dynamic error) {
+  GotrueResponse handleError(dynamic error) {
+    int? statusCode;
+    GotrueError errorRes;
+    if (error is http.Response) {
+      statusCode = error.statusCode;
+    }
+
     if (error is http.Response) {
       try {
         final parsedJson = json.decode(error.body) as Map<String, dynamic>;
@@ -21,35 +30,42 @@ class Fetch {
             parsedJson['error_description'] ??
             parsedJson['error'] ??
             json.encode(parsedJson);
-        return GotrueError(message as String);
+        errorRes = GotrueError(message as String);
       } on FormatException catch (_) {
-        return GotrueError(error.body);
+        errorRes = GotrueError(error.body);
       }
     } else {
-      return GotrueError(error.toString());
+      errorRes = GotrueError(error.toString());
     }
+
+    return GotrueResponse(error: errorRes, statusCode: statusCode);
   }
 
   Future<GotrueResponse> get(String url, {FetchOptions? options}) async {
-    final client = http.Client();
     try {
       final headers = options?.headers ?? {};
-      final http.Response response =
-          await client.get(Uri.parse(url), headers: headers);
+      final http.Response response = await (httpClient?.get ?? http.get)(
+        Uri.parse(url),
+        headers: headers,
+      );
       if (isSuccessStatusCode(response.statusCode)) {
         if (options?.noResolveJson == true) {
-          return GotrueResponse(rawData: response.body);
+          return GotrueResponse(
+            rawData: response.body,
+            statusCode: response.statusCode,
+          );
         } else {
           final jsonBody = json.decode(response.body);
-          return GotrueResponse(rawData: jsonBody);
+          return GotrueResponse(
+            rawData: jsonBody,
+            statusCode: response.statusCode,
+          );
         }
       } else {
         throw response;
       }
     } catch (e) {
-      return GotrueResponse(error: handleError(e));
-    } finally {
-      client.close();
+      return handleError(e);
     }
   }
 
@@ -58,26 +74,32 @@ class Fetch {
     dynamic body, {
     FetchOptions? options,
   }) async {
-    final client = http.Client();
     try {
       final bodyStr = json.encode(body ?? {});
       final headers = options?.headers ?? {};
-      final http.Response response =
-          await client.post(Uri.parse(url), headers: headers, body: bodyStr);
+      final http.Response response = await (httpClient?.post ?? http.post)(
+        Uri.parse(url),
+        headers: headers,
+        body: bodyStr,
+      );
       if (isSuccessStatusCode(response.statusCode)) {
         if (options?.noResolveJson == true) {
-          return GotrueResponse(rawData: response.body);
+          return GotrueResponse(
+            rawData: response.body,
+            statusCode: response.statusCode,
+          );
         } else {
           final jsonBody = json.decode(response.body);
-          return GotrueResponse(rawData: jsonBody);
+          return GotrueResponse(
+            rawData: jsonBody,
+            statusCode: response.statusCode,
+          );
         }
       } else {
         throw response;
       }
     } catch (e) {
-      return GotrueResponse(error: handleError(e));
-    } finally {
-      client.close();
+      return handleError(e);
     }
   }
 
@@ -86,26 +108,32 @@ class Fetch {
     dynamic body, {
     FetchOptions? options,
   }) async {
-    final client = http.Client();
     try {
       final bodyStr = json.encode(body ?? {});
       final headers = options?.headers ?? {};
-      final http.Response response =
-          await client.put(Uri.parse(url), headers: headers, body: bodyStr);
+      final http.Response response = await (httpClient?.put ?? http.put)(
+        Uri.parse(url),
+        headers: headers,
+        body: bodyStr,
+      );
       if (isSuccessStatusCode(response.statusCode)) {
         if (options?.noResolveJson == true) {
-          return GotrueResponse(rawData: response.body);
+          return GotrueResponse(
+            rawData: response.body,
+            statusCode: response.statusCode,
+          );
         } else {
           final jsonBody = json.decode(response.body);
-          return GotrueResponse(rawData: jsonBody);
+          return GotrueResponse(
+            rawData: jsonBody,
+            statusCode: response.statusCode,
+          );
         }
       } else {
         throw response;
       }
     } catch (e) {
-      return GotrueResponse(error: handleError(e));
-    } finally {
-      client.close();
+      return handleError(e);
     }
   }
 }

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -1,14 +1,22 @@
 import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/fetch.dart';
 import 'package:gotrue/src/fetch_options.dart';
+import 'package:http/http.dart';
 
 class GoTrueApi {
   String url;
   Map<String, String> headers;
   CookieOptions? cookieOptions;
+  final Client? _httpClient;
+  late final Fetch _fetch = Fetch(_httpClient);
 
-  GoTrueApi(this.url, {Map<String, String>? headers, this.cookieOptions})
-      : headers = headers ?? {};
+  GoTrueApi(
+    this.url, {
+    Map<String, String>? headers,
+    this.cookieOptions,
+    Client? httpClient,
+  })  : headers = headers ?? {},
+        _httpClient = httpClient;
 
   /// Creates a new user using their email address.
   ///
@@ -32,25 +40,31 @@ class GoTrueApi {
         urlParams.add('redirect_to=$encodedRedirectTo');
       }
       final queryString = urlParams.isNotEmpty ? '?${urlParams.join('&')}' : '';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/signup$queryString',
         body,
         options: fetchOptions,
       );
       final data = response.rawData as Map<String, dynamic>;
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else if (data['access_token'] == null) {
         // email validation required
         User? user;
         if (data['id'] != null) {
           user = User.fromJson(data);
         }
-        return GotrueSessionResponse(user: user);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          user: user,
+        );
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -72,17 +86,20 @@ class GoTrueApi {
         urlParams.add('redirect_to=$encodedRedirectTo');
       }
       final queryString = '?${urlParams.join('&')}';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/token$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -109,10 +126,12 @@ class GoTrueApi {
         'data': userMetadata,
       };
       final response =
-          await fetch.post('$url/signup', body, options: fetchOptions);
+          await _fetch.post('$url/signup', body, options: fetchOptions);
       final data = response.rawData as Map<String, dynamic>;
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+        );
       } else if ((response.rawData as Map<String, dynamic>)['access_token'] ==
           null) {
         // email validation required
@@ -120,11 +139,17 @@ class GoTrueApi {
         if (data['id'] != null) {
           user = User.fromJson(data);
         }
-        return GotrueSessionResponse(user: user);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          user: user,
+        );
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -144,17 +169,20 @@ class GoTrueApi {
       final body = {'phone': phone, 'password': password};
       final fetchOptions = FetchOptions(headers);
       const queryString = '?grant_type=password';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/token$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -175,17 +203,20 @@ class GoTrueApi {
       };
       final fetchOptions = FetchOptions(headers);
       const queryString = '?grant_type=id_token';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/token$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -206,15 +237,16 @@ class GoTrueApi {
         urlParams.add('redirect_to=$encodedRedirectTo');
       }
       final queryString = urlParams.isNotEmpty ? '?${urlParams.join('&')}' : '';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/magiclink$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueJsonResponse(error: response.error);
+        return GotrueJsonResponse.fromResponse(response: response);
       } else {
-        return GotrueJsonResponse(
+        return GotrueJsonResponse.fromResponse(
+          response: response,
           data: response.rawData as Map<String, dynamic>?,
         );
       }
@@ -231,11 +263,12 @@ class GoTrueApi {
       final body = {'phone': phone};
       final fetchOptions = FetchOptions(headers);
       final response =
-          await fetch.post('$url/otp', body, options: fetchOptions);
+          await _fetch.post('$url/otp', body, options: fetchOptions);
       if (response.error != null) {
-        return GotrueJsonResponse(error: response.error);
+        return GotrueJsonResponse.fromResponse(response: response);
       } else {
-        return GotrueJsonResponse(
+        return GotrueJsonResponse.fromResponse(
+          response: response,
           data: response.rawData as Map<String, dynamic>?,
         );
       }
@@ -263,9 +296,9 @@ class GoTrueApi {
       };
       final fetchOptions = FetchOptions(headers);
       final response =
-          await fetch.post('$url/verify', body, options: fetchOptions);
+          await _fetch.post('$url/verify', body, options: fetchOptions);
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else {
         Session session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
@@ -277,7 +310,10 @@ class GoTrueApi {
             session = session.copyWith(user: userResponse.user);
           }
         }
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));
@@ -298,15 +334,16 @@ class GoTrueApi {
         urlParams.add('redirect_to=$encodedRedirectTo');
       }
       final queryString = urlParams.isNotEmpty ? '?${urlParams.join('&')}' : '';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/invite$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueJsonResponse(error: response.error);
+        return GotrueJsonResponse.fromResponse(response: response);
       } else {
-        return GotrueJsonResponse(
+        return GotrueJsonResponse.fromResponse(
+          response: response,
           data: response.rawData as Map<String, dynamic>?,
         );
       }
@@ -329,15 +366,16 @@ class GoTrueApi {
         urlParams.add('redirect_to=$encodedRedirectTo');
       }
       final queryString = urlParams.isNotEmpty ? '?${urlParams.join('&')}' : '';
-      final response = await fetch.post(
+      final response = await _fetch.post(
         '$url/recover$queryString',
         body,
         options: fetchOptions,
       );
       if (response.error != null) {
-        return GotrueJsonResponse(error: response.error);
+        return GotrueJsonResponse.fromResponse(response: response);
       } else {
-        return GotrueJsonResponse(
+        return GotrueJsonResponse.fromResponse(
+          response: response,
           data: response.rawData as Map<String, dynamic>?,
         );
       }
@@ -352,7 +390,7 @@ class GoTrueApi {
       final headers = {...this.headers};
       headers['Authorization'] = 'Bearer $jwt';
       final options = FetchOptions(headers, noResolveJson: true);
-      final response = await fetch.post('$url/logout', {}, options: options);
+      final response = await _fetch.post('$url/logout', {}, options: options);
       return response;
     } catch (e) {
       return GotrueResponse(error: GotrueError(e.toString()));
@@ -377,12 +415,12 @@ class GoTrueApi {
       final headers = {...this.headers};
       headers['Authorization'] = 'Bearer $jwt';
       final options = FetchOptions(headers);
-      final response = await fetch.get('$url/user', options: options);
+      final response = await _fetch.get('$url/user', options: options);
       if (response.error != null) {
-        return GotrueUserResponse(error: response.error);
+        return GotrueUserResponse.fromResponse(response: response);
       } else {
         final user = User.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueUserResponse(user: user);
+        return GotrueUserResponse.fromResponse(response: response, user: user);
       }
     } catch (e) {
       return GotrueUserResponse(error: GotrueError(e.toString()));
@@ -399,12 +437,12 @@ class GoTrueApi {
       final headers = {...this.headers};
       headers['Authorization'] = 'Bearer $jwt';
       final options = FetchOptions(headers);
-      final response = await fetch.put('$url/user', body, options: options);
+      final response = await _fetch.put('$url/user', body, options: options);
       if (response.error != null) {
-        return GotrueUserResponse(error: response.error);
+        return GotrueUserResponse.fromResponse(response: response);
       } else {
         final user = User.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueUserResponse(user: user);
+        return GotrueUserResponse.fromResponse(response: response, user: user);
       }
     } catch (e) {
       return GotrueUserResponse(error: GotrueError(e.toString()));
@@ -422,14 +460,17 @@ class GoTrueApi {
         headers['Authorization'] = 'Bearer $jwt';
       }
       final options = FetchOptions(headers);
-      final response = await fetch
+      final response = await _fetch
           .post('$url/token?grant_type=refresh_token', body, options: options);
       if (response.error != null) {
-        return GotrueSessionResponse(error: response.error);
+        return GotrueSessionResponse.fromResponse(response: response);
       } else {
         final session =
             Session.fromJson(response.rawData as Map<String, dynamic>);
-        return GotrueSessionResponse(data: session);
+        return GotrueSessionResponse.fromResponse(
+          response: response,
+          data: session,
+        );
       }
     } catch (e) {
       return GotrueSessionResponse(error: GotrueError(e.toString()));

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -5,6 +5,7 @@ import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/constants.dart';
 import 'package:gotrue/src/subscription.dart';
 import 'package:gotrue/src/uuid.dart';
+import 'package:http/http.dart';
 
 class GoTrueClient {
   /// Namespace for the GoTrue API methods.
@@ -27,6 +28,7 @@ class GoTrueClient {
     Map<String, String>? headers,
     bool? autoRefreshToken,
     CookieOptions? cookieOptions,
+    Client? httpClient,
   }) {
     this.autoRefreshToken = autoRefreshToken ?? true;
 
@@ -35,7 +37,12 @@ class GoTrueClient {
       ...Constants.defaultHeaders,
       if (headers != null) ...headers,
     };
-    api = GoTrueApi(_url, headers: _header, cookieOptions: cookieOptions);
+    api = GoTrueApi(
+      _url,
+      headers: _header,
+      cookieOptions: cookieOptions,
+      httpClient: httpClient,
+    );
   }
 
   /// Returns the user data, if there is a logged in user.

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -296,7 +296,7 @@ class GoTrueClient {
       final response = await api.signOut(accessToken);
       if (response.error != null) return response;
     }
-    return GotrueResponse();
+    return const GotrueResponse();
   }
 
   // Receive a notification every time an auth event happens.

--- a/lib/src/gotrue_response.dart
+++ b/lib/src/gotrue_response.dart
@@ -4,23 +4,38 @@ import 'package:gotrue/src/subscription.dart';
 import 'package:gotrue/src/user.dart';
 
 class GotrueResponse {
-  GotrueError? error;
-  dynamic rawData;
+  final GotrueError? error;
+  final dynamic rawData;
+  final int? statusCode;
 
-  GotrueResponse({this.rawData, this.error});
+  const GotrueResponse({this.rawData, this.error, this.statusCode});
 }
 
 class GotrueJsonResponse extends GotrueResponse {
-  Map<String, dynamic>? data;
+  final Map<String, dynamic>? data;
 
-  GotrueJsonResponse({this.data, GotrueError? error}) : super(error: error);
+  const GotrueJsonResponse({
+    this.data,
+    GotrueError? error,
+    int? statusCode,
+  }) : super(
+          error: error,
+          statusCode: statusCode,
+        );
+
+  GotrueJsonResponse.fromResponse({required GotrueResponse response, this.data})
+      : super(
+          error: response.error,
+          statusCode: response.statusCode,
+          rawData: response.rawData,
+        );
 }
 
 class GotrueSessionResponse extends GotrueResponse {
-  Session? data;
-  String? provider;
-  String? url;
-  User? user;
+  final Session? data;
+  final String? provider;
+  final String? url;
+  final User? user;
 
   GotrueSessionResponse({
     this.data,
@@ -28,22 +43,52 @@ class GotrueSessionResponse extends GotrueResponse {
     this.url,
     User? user,
     GotrueError? error,
+    int? statusCode,
   })  : user = user ?? data?.user,
-        super(error: error);
+        super(
+          error: error,
+          statusCode: statusCode,
+        );
+
+  GotrueSessionResponse.fromResponse({
+    required GotrueResponse response,
+    this.data,
+    this.provider,
+    this.url,
+    User? user,
+  })  : user = user ?? data?.user,
+        super(
+          error: response.error,
+          statusCode: response.statusCode,
+        );
 }
 
 class GotrueUserResponse extends GotrueResponse {
-  User? user;
+  final User? user;
 
   User? get data {
     return user;
   }
 
-  GotrueUserResponse({this.user, GotrueError? error}) : super(error: error);
+  const GotrueUserResponse({
+    this.user,
+    GotrueError? error,
+    int? statusCode,
+  }) : super(
+          error: error,
+          statusCode: statusCode,
+        );
+
+  GotrueUserResponse.fromResponse({required GotrueResponse response, this.user})
+      : super(
+          error: response.error,
+          statusCode: response.statusCode,
+        );
 }
 
 class GotrueSubscription extends GotrueResponse {
-  Subscription? data;
+  final Subscription? data;
 
-  GotrueSubscription({this.data, GotrueError? error}) : super(error: error);
+  const GotrueSubscription({this.data, GotrueError? error})
+      : super(error: error);
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -5,6 +5,8 @@ import 'package:gotrue/gotrue.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 
+import 'custom_http_client.dart';
+
 void main() {
   final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
 
@@ -17,7 +19,7 @@ void main() {
   final email = env['GOTRUE_USER_EMAIL'] ?? 'fake$timestamp@email.com';
   final password = env['GOTRUE_USER_PASS'] ?? 'secret';
 
-  group('client', () {
+  group('Client with default http client', () {
     late GoTrueClient client;
     late GoTrueClient clientWithAuthConfirmOff;
 
@@ -177,6 +179,22 @@ void main() {
       final error = res.error!;
       expect(error.message, isNotNull);
       expect(data, isNull);
+    });
+  });
+
+  group("Client with custom http client", () {
+    late GoTrueClient client;
+
+    setUpAll(() {
+      client = GoTrueClient(
+        url: gotrueUrl,
+        httpClient: CustomHttpClient(),
+      );
+    });
+
+    test('signIn()', () async {
+      final response = await client.signIn(email: email, password: password);
+      expect(response.statusCode, 420);
     });
   });
 

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -1,0 +1,13 @@
+import 'package:http/http.dart';
+
+class CustomHttpClient extends BaseClient {
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    //Return custom status code to check for usage of this client.
+    return StreamedResponse(
+      request.finalize(),
+      420,
+      request: request,
+    );
+  }
+}


### PR DESCRIPTION
# Motivation
Same reason as https://github.com/supabase-community/postgrest-dart/pull/66
# Implementation
When writing the test, I realized that the response doesn't include the status code. I think that's a nice to have. When trying to implement the status code I realized that e.g. `GotrueUserResponse` does extend `GotrueResponse`, but parameter like `rawData` aren't copied to the new instance. When adding the status code to `GotrueResponse` you would have to repeatedly pass it to the new instance. So I created helper constructors to create a new instance from the general `GotrueResponse`. So `rawData` and `statusCode` are copied too.
In addition, I made them all `final`.
