### PR TITLE
Using JWT Decode without External Package

### DIFF
--- a/lib/gotrue.dart
+++ b/lib/gotrue.dart
@@ -7,6 +7,7 @@ export 'src/gotrue_api.dart';
 export 'src/gotrue_client.dart';
 export 'src/gotrue_error.dart';
 export 'src/gotrue_response.dart';
+export 'src/jwt_decode.dart';
 export 'src/open_id_connect_credentials.dart';
 export 'src/provider.dart';
 export 'src/session.dart';

--- a/lib/src/jwt_decode.dart
+++ b/lib/src/jwt_decode.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+Map<String, dynamic> jwtDecode(String token) {
+  final parts = token.split('.');
+  // Check if the JWT consists header, payload, and signature
+  if (parts.length != 3) {
+    throw Exception('invalid token');
+  }
+
+  String str = parts[1].replaceAll('-', '+').replaceAll('_', '/');
+
+  switch (str.length % 4) {
+    case 0:
+      break;
+    case 2:
+      str += '==';
+      break;
+    case 3:
+      str += '=';
+      break;
+    default:
+      throw Exception('Illegal base64url string!');
+  }
+
+  // Returning the payload as a map
+  final payload = utf8.decode(base64Url.decode(str));
+  final payloadMap = jsonDecode(payload) as Map<String, dynamic>;
+  return payloadMap;
+}

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
+import 'package:gotrue/src/jwt_decode.dart';
 import 'package:gotrue/src/user.dart';
-import 'package:jwt_decode/jwt_decode.dart';
 
 class Session {
   final String accessToken;
@@ -42,7 +42,7 @@ class Session {
 
   int? get expiresAt {
     try {
-      final payload = Jwt.parseJwt(accessToken);
+      final payload = jwtDecode(accessToken);
       return payload['exp'] as int;
     } catch (_) {
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  jwt_decode: ^0.3.1
 
 dev_dependencies:
   dotenv: ^3.0.0

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dotenv/dotenv.dart' show env, load;
 import 'package:gotrue/gotrue.dart';
-import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 
 import 'custom_http_client.dart';
@@ -93,9 +92,9 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user?.id, isA<String>());
 
-      final payload = Jwt.parseJwt(data!.accessToken);
-      final persistSession = json.decode(data.persistSessionString);
-      // ignore: avoid_dynamic_calls
+      final payload = jwtDecode(data!.accessToken);
+      final persistSession =
+          json.decode(data.persistSessionString) as Map<String, dynamic>;
       expect(payload['exp'], persistSession['expiresAt']);
     });
 


### PR DESCRIPTION
### Current Behavior
- Our gotrue package uses external JWT package

### New Behavior
- Uses our own minimalist JWT decode file