### PR TITLE
fix: Retry access token refresh when offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- fix: Retry access token refresh when offline ([#63](https://github.com/supabase-community/gotrue-dart/pull/63))
+
 ## [0.2.0]
 
 - BREAKING: `user` will be returned when signing up with auto confirm off ([#63](https://github.com/supabase-community/gotrue-dart/pull/63))

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:gotrue/src/fetch_options.dart';
 import 'package:gotrue/src/gotrue_error.dart';
@@ -25,6 +26,11 @@ class Fetch {
       } on FormatException catch (_) {
         return GotrueError(error.body);
       }
+    } else if (error is SocketException) {
+      return GotrueError(
+        error.toString(),
+        statusCode: error.runtimeType.toString(),
+      );
     } else {
       return GotrueError(error.toString());
     }
@@ -74,6 +80,8 @@ class Fetch {
       } else {
         throw response;
       }
+    } on SocketException catch (e) {
+      return GotrueResponse(error: handleError(e));
     } catch (e) {
       return GotrueResponse(error: handleError(e));
     } finally {

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -38,7 +38,7 @@ class Fetch {
         errorRes = GotrueError(error.body);
       }
     } else if (error is SocketException) {
-      return GotrueError(
+      errorRes = GotrueError(
         error.toString(),
         statusCode: error.runtimeType.toString(),
       );
@@ -107,7 +107,7 @@ class Fetch {
         throw response;
       }
     } on SocketException catch (e) {
-      return GotrueResponse(error: handleError(e));
+      return handleError(e);
     } catch (e) {
       return handleError(e);
     }

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:gotrue/src/fetch_options.dart';
 import 'package:gotrue/src/gotrue_error.dart';
 import 'package:gotrue/src/gotrue_response.dart';
 import 'package:http/http.dart' as http;
+import 'package:universal_io/io.dart';
 
 final Fetch fetch = Fetch();
 

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -7,8 +7,6 @@ import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:universal_io/io.dart';
 
-final Fetch fetch = Fetch();
-
 class Fetch {
   final Client? httpClient;
 

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -37,14 +37,14 @@ class GoTrueApi {
         body,
         options: fetchOptions,
       );
-      final data = response.rawData as Map<String, dynamic>;
+      final data = response.rawData as Map<String, dynamic>?;
       if (response.error != null) {
         return GotrueSessionResponse(error: response.error);
-      } else if (data['access_token'] == null) {
+      } else if (data?['access_token'] == null) {
         // email validation required
         User? user;
-        if (data['id'] != null) {
-          user = User.fromJson(data);
+        if (data?['id'] != null) {
+          user = User.fromJson(data!);
         }
         return GotrueSessionResponse(user: user);
       } else {

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -431,9 +431,7 @@ class GoTrueClient {
     final expiresAt = session.expiresAt;
 
     if (autoRefreshToken && expiresAt != null) {
-      if (_refreshTokenTimer != null) {
-        _refreshTokenTimer!.cancel();
-      }
+      _refreshTokenTimer?.cancel();
 
       final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
       final expiresIn = expiresAt - timeNow;
@@ -449,6 +447,7 @@ class GoTrueClient {
   }
 
   void _setTokenRefreshTimer(Duration timerDuration) {
+    _refreshTokenTimer?.cancel();
     _refreshTokenTimer = Timer(timerDuration, () {
       _callRefreshToken();
     });

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -440,7 +440,6 @@ class GoTrueClient {
       final refreshDurationBeforeExpires = expiresIn > 60 ? 60 : 1;
       final nextDuration = expiresIn - refreshDurationBeforeExpires;
       if (nextDuration > 0) {
-        _refreshTokenRetryCount = 0;
         final timerDuration = Duration(seconds: nextDuration);
         _setTokenRefreshTimer(timerDuration);
       } else {
@@ -490,6 +489,7 @@ class GoTrueClient {
       final error = GotrueError('Invalid session data.');
       return GotrueSessionResponse(error: error);
     }
+    _refreshTokenRetryCount = 0;
 
     _saveSession(response.data!);
     _notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);

--- a/lib/src/gotrue_error.dart
+++ b/lib/src/gotrue_error.dart
@@ -1,10 +1,14 @@
 class GotrueError {
   String message;
+  String? statusCode;
 
-  GotrueError(this.message);
+  GotrueError(
+    this.message, {
+    this.statusCode,
+  });
 
   @override
   String toString() {
-    return 'GotrueError(message: $message)';
+    return 'GotrueError(message: $message, statusCode: $statusCode)';
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,16 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
 version: 0.2.0
-homepage: 'https://supabase.io'
-repository: 'https://github.com/supabase/gotrue-dart'
+homepage: "https://supabase.io"
+repository: "https://github.com/supabase/gotrue-dart"
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.0
   jwt_decode: ^0.3.1
+  universal_io: ^2.0.4
 
 dev_dependencies:
   dotenv: ^3.0.0


### PR DESCRIPTION
Currently when accessToken refresh fails for any reason, gotrue-dart never retries to update access token and the user is signed out. This PR fixes that by retrying to refresh the token if it fails due to network error. 

It will also not sign a user out just because a token refresh failed. Instead, it will retry every 5 seconds to get a new token. 

Related https://github.com/supabase-community/supabase-flutter/issues/33