### PR TITLE
fix: use completer in the retry logic to return value when token refresh is complete

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -8,7 +8,9 @@ class Constants {
   };
   static const int defaultExpiryMargin = 60 * 1000;
   static const String defaultStorageKey = 'supabase.auth.token';
+  static const expiryMargin = Duration(seconds: 10);
   static const int maxRetryCount = 10;
+  static const retryInterval = Duration(milliseconds: 200);
 }
 
 enum AuthChangeEvent {

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -8,6 +8,7 @@ class Constants {
   };
   static const int defaultExpiryMargin = 60 * 1000;
   static const String defaultStorageKey = 'supabase.auth.token';
+  static const int maxRetryCount = 10;
 }
 
 enum AuthChangeEvent {

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -346,7 +346,7 @@ class GoTrueClient {
       }
 
       final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
-      if (expiresAt < timeNow) {
+      if (expiresAt < (timeNow - Constants.expiryMargin.inSeconds)) {
         if (autoRefreshToken && session.refreshToken != null) {
           return _callRefreshToken(
             refreshCompleter,

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -504,6 +504,7 @@ class GoTrueClient {
           refreshToken: refreshToken,
           accessToken: accessToken,
         );
+        return completer.future;
       }
       completer.complete(response);
       return completer.future;

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -506,6 +506,7 @@ class GoTrueClient {
     _notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);
     _notifyAllSubscribers(AuthChangeEvent.signedIn);
 
+    _callRefreshTokenCompleter.complete(response);
     return _callRefreshTokenCompleter.future;
   }
 

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/constants.dart';
@@ -498,7 +499,7 @@ class GoTrueClient {
     if (response.error != null) {
       if (response.error!.statusCode == 'SocketException') {
         _setTokenRefreshTimer(
-          const Duration(seconds: 5),
+          Constants.retryInterval * pow(2, _refreshTokenRetryCount),
           completer,
           refreshToken: refreshToken,
           accessToken: accessToken,


### PR DESCRIPTION
This PR is a rework of https://github.com/supabase-community/gotrue-dart/pull/71 pretty much. 

Instead of just retrying token refresh every 5 seconds, this PR will use a `Completer` to return a valid `GoTrueSessionResponse` upon successful token refresh after retry. 