### PR TITLE
fix: type casting of phone auth response

### DIFF
--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -127,13 +127,12 @@ class GoTrueApi {
       };
       final response =
           await _fetch.post('$url/signup', body, options: fetchOptions);
-      final data = response.rawData as Map<String, dynamic>;
+      final data = response.rawData as Map<String, dynamic>?;
       if (response.error != null) {
         return GotrueSessionResponse.fromResponse(
           response: response,
         );
-      } else if ((response.rawData as Map<String, dynamic>)['access_token'] ==
-          null) {
+      } else if (data != null && data['access_token'] == null) {
         // email validation required
         User? user;
         if (data['id'] != null) {


### PR DESCRIPTION
Currently, when there is an error with phone auth sign up, type cast error is thrown. This PR fixes that bug and the developers will be able to see the actual error. 

Fixes https://github.com/supabase-community/supabase-flutter/issues/132