### PR TITLE
fix: encoding issue with some languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.0-dev.4]
+
+- fix: encoding issue with some languages([#89](https://github.com/supabase-community/gotrue-dart/pull/89))
+
 ## [1.0.0-dev.3]
 
 - BREAKING: `data` property of `GotrueSessionResponse` is renamed to `session`([#87](https://github.com/supabase-community/gotrue-dart/pull/87))

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -47,7 +47,7 @@ class GotrueFetch {
           statusCode: response.statusCode,
         );
       } else {
-        final jsonBody = json.decode(response.body);
+        final jsonBody = json.decode(utf8.decode(response.bodyBytes));
         return GotrueResponse(
           rawData: jsonBody,
           statusCode: response.statusCode,
@@ -77,7 +77,7 @@ class GotrueFetch {
           statusCode: response.statusCode,
         );
       } else {
-        final jsonBody = json.decode(response.body);
+        final jsonBody = json.decode(utf8.decode(response.bodyBytes));
         return GotrueResponse(
           rawData: jsonBody,
           statusCode: response.statusCode,
@@ -107,7 +107,7 @@ class GotrueFetch {
           statusCode: response.statusCode,
         );
       } else {
-        final jsonBody = json.decode(response.body);
+        final jsonBody = json.decode(utf8.decode(response.bodyBytes));
         return GotrueResponse(
           rawData: jsonBody,
           statusCode: response.statusCode,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.3';
+const version = '1.0.0-dev.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.0.0-dev.3
+version: 1.0.0-dev.4
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -150,7 +150,12 @@ void main() {
 
     test('Update user', () async {
       final response = await client.update(
-        UserAttributes(data: {'hello': 'world'}),
+        UserAttributes(data: {
+          'hello': 'world',
+          'japanese': '日本語',
+          'korean': '한국어',
+          'arabic': 'عربى',
+        }),
       );
       final data = response.data;
       expect(data?.id, isA<String>());
@@ -163,6 +168,9 @@ void main() {
       expect(user, isNotNull);
       expect(user?.id, isA<String>());
       expect(user?.userMetadata?['hello'], 'world');
+      expect(user?.userMetadata?['japanese'], '日本語');
+      expect(user?.userMetadata?['korean'], '한국어');
+      expect(user?.userMetadata?['arabic'], 'عربى');
     });
 
     test('signIn with OpenIDConnect wrong id_token', () async {


### PR DESCRIPTION
Right now Japanese and Korean breaks when they are in the user metadata. This PR fixes it. Haven't look into it too much , but not sure why the same happens with Postgrest or realtime, but they are fine. 

fixes https://github.com/supabase-community/supabase-flutter/issues/212