### PR TITLE
fix: verify otp throws on verification.

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -284,16 +284,18 @@ class GoTrueClient {
     final response = await _fetch
         .request('$_url/verify', RequestMethodType.post, options: fetchOptions);
 
-    if (response.session == null) {
+    final authResponse = AuthResponse.fromJson(response);
+
+    if (authResponse.session == null) {
       throw AuthException(
         'An error occurred on token verification.',
       );
     }
 
-    _saveSession(response.session!);
+    _saveSession(authResponse.session!);
     _notifyAllSubscribers(AuthChangeEvent.signedIn);
 
-    return response;
+    return authResponse;
   }
 
   /// Force refreshes the session including the user data in case it was updated

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -172,7 +172,7 @@ class GoTrueClient {
 
     final authResponse = AuthResponse.fromJson(response);
 
-    if (authResponse.session != null) {
+    if (authResponse.session?.accessToken != null) {
       _saveSession(authResponse.session!);
       _notifyAllSubscribers(AuthChangeEvent.signedIn);
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, verify otp throws upon successful verification. This PR fixes that.
Fixes https://github.com/supabase-community/supabase-flutter/issues/251

## What is the current behavior?

Successful verify throws

## What is the new behavior?

Verification should go through successfully without any issues.