### PR TITLE
fix: properly add redirect_to when making request

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -47,7 +47,7 @@ class GotrueFetch {
 
     final qs = options?.query ?? {};
     if (options?.redirectTo != null) {
-      qs['redirect_to'] = Uri.encodeComponent(options!.redirectTo!);
+      qs['redirect_to'] = options!.redirectTo!;
     }
     Uri uri = Uri.parse(url);
     uri = uri.replace(queryParameters: qs);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, `redirect_to` parameter of the `request` method is being URI encoded twice, resulting in wrong value being passed as the query parameter. This PR fixes it.

Fixes https://github.com/supabase-community/supabase-flutter/issues/244

## What is the current behavior?

Because redirect_to is not being passed properly, `emailRedirectTo` is not working

## What is the new behavior?

`emailRedirectTo` should be working with this one.
