### PR TITLE
feat: fail to getSessionFromUrl throws error on onAuthStateChange

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -358,7 +358,7 @@ class GoTrueClient {
 
     final errorDescription = url.queryParameters['error_description'];
     if (errorDescription != null) {
-      throw AuthException(errorDescription);
+      throw _notifyException(AuthException(errorDescription));
     }
 
     final accessToken = url.queryParameters['access_token'];
@@ -368,16 +368,16 @@ class GoTrueClient {
     final providerToken = url.queryParameters['provider_token'];
 
     if (accessToken == null) {
-      throw AuthException('No access_token detected.');
+      throw _notifyException(AuthException('No access_token detected.'));
     }
     if (expiresIn == null) {
-      throw AuthException('No expires_in detected.');
+      throw _notifyException(AuthException('No expires_in detected.'));
     }
     if (refreshToken == null) {
-      throw AuthException('No refresh_token detected.');
+      throw _notifyException(AuthException('No refresh_token detected.'));
     }
     if (tokenType == null) {
-      throw AuthException('No token_type detected.');
+      throw _notifyException(AuthException('No token_type detected.'));
     }
 
     final headers = {..._headers};
@@ -387,7 +387,7 @@ class GoTrueClient {
         options: options);
     final user = UserResponse.fromJson(response).user;
     if (user == null) {
-      throw AuthException('No user found. ');
+      throw _notifyException(AuthException('No user found.'));
     }
 
     final session = Session(
@@ -621,5 +621,10 @@ class GoTrueClient {
 
   void _notifyAllSubscribers(AuthChangeEvent event) {
     _onAuthStateChangeController.add(AuthState(event, currentSession));
+  }
+
+  Exception _notifyException(Exception exception) {
+    _onAuthStateChangeController.addError(exception);
+    return exception;
   }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -89,6 +89,7 @@ void main() {
           'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
       try {
         await client.getSessionFromUrl(urlWithoutAccessToken);
+        fail('getSessionFromUrl did not throw exception');
       } catch (_) {}
     });
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -76,21 +76,21 @@ void main() {
       expect(data?.user.userMetadata, {"Hello": "World"});
     });
 
-    test('Parsing invalid URL should emit Exception on onAuthStateChange',
-        () async {
-      // expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
+    // test('Parsing invalid URL should emit Exception on onAuthStateChange',
+    //     () async {
+    //   expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
 
-      const expiresIn = 12345;
-      const refreshToken = 'my_refresh_token';
-      const tokenType = 'my_token_type';
-      const providerToken = 'my_provider_token_with_fragment';
+    //   const expiresIn = 12345;
+    //   const refreshToken = 'my_refresh_token';
+    //   const tokenType = 'my_token_type';
+    //   const providerToken = 'my_provider_token_with_fragment';
 
-      final urlWithoutAccessToken = Uri.parse(
-          'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
-      try {
-        await client.getSessionFromUrl(urlWithoutAccessToken);
-      } catch (_) {}
-    });
+    //   final urlWithoutAccessToken = Uri.parse(
+    //       'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
+    //   try {
+    //     await client.getSessionFromUrl(urlWithoutAccessToken);
+    //   } catch (_) {}
+    // });
 
     test('Subscribe a listener', () async {
       /// auth subsctiption callback has been called once with the signup above

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -46,7 +46,7 @@ void main() {
       );
       onAuthSubscription = client.onAuthStateChange.listen((_) {
         subscriptionCallbackCalledCount++;
-      });
+      }, onError: (_) {});
     });
 
     test('basic json parsing', () async {
@@ -76,21 +76,21 @@ void main() {
       expect(data?.user.userMetadata, {"Hello": "World"});
     });
 
-    // test('Parsing invalid URL should emit Exception on onAuthStateChange',
-    //     () async {
-    //   expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
+    test('Parsing invalid URL should emit Exception on onAuthStateChange',
+        () async {
+      expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
 
-    //   const expiresIn = 12345;
-    //   const refreshToken = 'my_refresh_token';
-    //   const tokenType = 'my_token_type';
-    //   const providerToken = 'my_provider_token_with_fragment';
+      const expiresIn = 12345;
+      const refreshToken = 'my_refresh_token';
+      const tokenType = 'my_token_type';
+      const providerToken = 'my_provider_token_with_fragment';
 
-    //   final urlWithoutAccessToken = Uri.parse(
-    //       'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
-    //   try {
-    //     await client.getSessionFromUrl(urlWithoutAccessToken);
-    //   } catch (_) {}
-    // });
+      final urlWithoutAccessToken = Uri.parse(
+          'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
+      try {
+        await client.getSessionFromUrl(urlWithoutAccessToken);
+      } catch (_) {}
+    });
 
     test('Subscribe a listener', () async {
       /// auth subsctiption callback has been called once with the signup above

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -76,10 +76,9 @@ void main() {
       expect(data?.user.userMetadata, {"Hello": "World"});
     });
 
-    test(
-        'Trying to parse invalid URL should emit Exception on onAuthStateChange',
+    test('Parsing invalid URL should emit Exception on onAuthStateChange',
         () async {
-      expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
+      // expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
 
       const expiresIn = 12345;
       const refreshToken = 'my_refresh_token';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -26,6 +26,7 @@ void main() {
     late GoTrueClient clientWithAuthConfirmOff;
 
     int subscriptionCallbackCalledCount = 0;
+
     late StreamSubscription<AuthState> onAuthSubscription;
 
     setUpAll(() {
@@ -73,6 +74,21 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user.id, isA<String>());
       expect(data?.user.userMetadata, {"Hello": "World"});
+    });
+
+    test(
+        'Trying to parse invalid URL should emit Exception on onAuthStateChange',
+        () async {
+      expect(client.onAuthStateChange, emitsError(isA<AuthException>()));
+
+      const expiresIn = 12345;
+      const refreshToken = 'my_refresh_token';
+      const tokenType = 'my_token_type';
+      const providerToken = 'my_provider_token_with_fragment';
+
+      final urlWithoutAccessToken = Uri.parse(
+          'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
+      client.getSessionFromUrl(urlWithoutAccessToken);
     });
 
     test('Subscribe a listener', () async {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -88,7 +88,9 @@ void main() {
 
       final urlWithoutAccessToken = Uri.parse(
           'http://my-callback-url.com/welcome#expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken');
-      client.getSessionFromUrl(urlWithoutAccessToken);
+      try {
+        await client.getSessionFromUrl(urlWithoutAccessToken);
+      } catch (_) {}
     });
 
     test('Subscribe a listener', () async {


### PR DESCRIPTION
## Feature Proposal

Currently using supabase-flutter, there is no way to detect the exception thrown to parse deep links other than the initial link using `initialSession`

```dart
try {
  await SupabaseAuth.initialSession;
} catch(error) {
  // handle initial error here
}
```

This PR allows the users to use `onAuthStateChange` to listen to exceptions thrown during deep link parsing like this:

```dart
supabase.auth.onAuthStateChange.listen(
  (data) {
    // handle auth state change here
  },
  onError: (error) {
    // handle parsing error here.
  }
);
```

Fixes https://github.com/supabase-community/supabase-flutter/issues/211
