### PR TITLE
fix: avoid positive lookbehind in snake case extension

### DIFF
--- a/lib/src/types/auth_response.dart
+++ b/lib/src/types/auth_response.dart
@@ -84,9 +84,22 @@ class GenerateLinkProperties {
 
 extension ToSnakeCase on Enum {
   String get snakeCase {
-    RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
-    return name
-        .replaceAllMapped(exp, (Match m) => ('_${m.group(0)}'))
-        .toLowerCase();
+    if (name.isEmpty) {
+      return name;
+    }
+    var a = 'a'.codeUnitAt(0), z = 'z'.codeUnitAt(0);
+    var A = 'A'.codeUnitAt(0), Z = 'Z'.codeUnitAt(0);
+    var result = StringBuffer()..write(name[0].toLowerCase());
+    for (var i = 1; i < name.length; i++) {
+      var char = name.codeUnitAt(i);
+      if (A <= char && char <= Z) {
+        var pChar = name.codeUnitAt(i - 1);
+        if (a <= pChar && pChar <= z) {
+          result.write('_');
+        }
+      }
+      result.write(name[i].toLowerCase());
+    }
+    return result.toString();
   }
 }

--- a/lib/src/types/auth_response.dart
+++ b/lib/src/types/auth_response.dart
@@ -84,9 +84,6 @@ class GenerateLinkProperties {
 
 extension ToSnakeCase on Enum {
   String get snakeCase {
-    if (name.isEmpty) {
-      return name;
-    }
     var a = 'a'.codeUnitAt(0), z = 'z'.codeUnitAt(0);
     var A = 'A'.codeUnitAt(0), Z = 'Z'.codeUnitAt(0);
     var result = StringBuffer()..write(name[0].toLowerCase());

--- a/lib/src/types/auth_response.dart
+++ b/lib/src/types/auth_response.dart
@@ -84,13 +84,13 @@ class GenerateLinkProperties {
 
 extension ToSnakeCase on Enum {
   String get snakeCase {
-    var a = 'a'.codeUnitAt(0), z = 'z'.codeUnitAt(0);
-    var A = 'A'.codeUnitAt(0), Z = 'Z'.codeUnitAt(0);
-    var result = StringBuffer()..write(name[0].toLowerCase());
+    final a = 'a'.codeUnitAt(0), z = 'z'.codeUnitAt(0);
+    final A = 'A'.codeUnitAt(0), Z = 'Z'.codeUnitAt(0);
+    final result = StringBuffer()..write(name[0].toLowerCase());
     for (var i = 1; i < name.length; i++) {
-      var char = name.codeUnitAt(i);
+      final char = name.codeUnitAt(i);
       if (A <= char && char <= Z) {
-        var pChar = name.codeUnitAt(i - 1);
+        final pChar = name.codeUnitAt(i - 1);
         if (a <= pChar && pChar <= z) {
           result.write('_');
         }

--- a/test/auth_response_test.dart
+++ b/test/auth_response_test.dart
@@ -1,0 +1,46 @@
+// ignore_for_file: constant_identifier_names
+
+import 'package:gotrue/src/types/auth_response.dart';
+import 'package:test/test.dart';
+
+enum TestEnum {
+  camelCase,
+  PascalCase,
+  UPPERCASE,
+  lowercase,
+  snake_case,
+  UPPER_SNAKE_CASE,
+  camel_Snake_Case,
+}
+
+void main() {
+  group('ToSnakeCase extension', () {
+    test('should convert camelCase to snake_case', () {
+      expect(TestEnum.camelCase.snakeCase, 'camel_case');
+    });
+
+    test('should convert PascalCase to snake_case', () {
+      expect(TestEnum.PascalCase.snakeCase, 'pascal_case');
+    });
+
+    test('should convert UPPERCASE to snake_case', () {
+      expect(TestEnum.UPPERCASE.snakeCase, 'uppercase');
+    });
+
+    test('should convert lowercase to snake_case', () {
+      expect(TestEnum.lowercase.snakeCase, 'lowercase');
+    });
+
+    test('should convert snake_case to snake_case', () {
+      expect(TestEnum.snake_case.snakeCase, 'snake_case');
+    });
+
+    test('should convert UPPER_SNAKE_CASE to snake_case', () {
+      expect(TestEnum.UPPER_SNAKE_CASE.snakeCase, 'upper_snake_case');
+    });
+
+    test('should convert camel_Snake_Case to snake_case', () {
+      expect(TestEnum.camel_Snake_Case.snakeCase, 'camel_snake_case');
+    });
+  });
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #100

## What is the current behavior?

Use reg exp to generate the snake cases

## What is the new behavior?

Generate the snake cases without using reg exp

