### PR TITLE
fix: redirect_to double URL encoding issue

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -499,8 +499,7 @@ class GoTrueClient {
       urlParams['scopes'] = scopes;
     }
     if (redirectTo != null) {
-      final encodedRedirectTo = Uri.encodeComponent(redirectTo);
-      urlParams['redirect_to'] = encodedRedirectTo;
+      urlParams['redirect_to'] = redirectTo;
     }
     if (queryParams != null) {
       urlParams.addAll(queryParams);

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -432,14 +432,12 @@ class GoTrueClient {
       'email': email,
       'gotrue_meta_security': {'captcha_token': captchaToken},
     };
-    final urlParams = <String, String>{};
-    if (redirectTo != null) {
-      final encodedRedirectTo = Uri.encodeComponent(redirectTo);
-      urlParams['redirect_to'] = encodedRedirectTo;
-    }
 
-    final fetchOptions =
-        GotrueRequestOptions(headers: _headers, body: body, query: urlParams);
+    final fetchOptions = GotrueRequestOptions(
+      headers: _headers,
+      body: body,
+      redirectTo: redirectTo,
+    );
     await _fetch.request(
       '$_url/recover',
       RequestMethodType.post,

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -270,6 +270,14 @@ void main() {
         expect(res.provider, Provider.google);
       });
 
+      test('signIn() with Provider with redirectTo', () async {
+        final res = await client.getOAuthSignInUrl(
+            provider: Provider.google, redirectTo: 'https://supabase.com');
+        expect(res.url,
+            '$gotrueUrl/authorize?provider=google&redirect_to=https%3A%2F%2Fsupabase.com');
+        expect(res.provider, Provider.google);
+      });
+
       test('signIn() with Provider can append a redirectUrl', () async {
         final res = await client.getOAuthSignInUrl(
             provider: Provider.google,


### PR DESCRIPTION
## What kind of change does this PR introduce?

There were some other `redirect_to` issue where the parameter was URL encoded twice. This fixes it.

Fixes https://github.com/supabase-community/supabase-flutter/issues/261