### PR TITLE
Use correct token for refreshing 

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -580,7 +580,7 @@ class GoTrueClient {
     final jwt = accessToken ?? currentSession?.accessToken;
 
     try {
-      final body = {'refresh_token': refreshToken};
+      final body = {'refresh_token': token};
       if (jwt != null) {
         _headers['Authorization'] = 'Bearer $jwt';
       }
@@ -609,7 +609,7 @@ class GoTrueClient {
       _setTokenRefreshTimer(
         Constants.retryInterval * pow(2, _refreshTokenRetryCount),
         completer,
-        refreshToken: refreshToken,
+        refreshToken: token,
         accessToken: accessToken,
       );
       return completer.future;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the lib uses `refreshToken` but it may be `null`. There is a check in the first line and we should use that variable. 

## What is the new behavior?

Use `token` (which is `refreshToken ?? currentSession?.refreshToken`) instead of `refreshToken`

## Additional context
